### PR TITLE
feat: add configuration for request logger and improve cache key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ After installing, the package will automatically register its service provider.
     Schedule::command('save:requests')->everyMinute();
     ```
 
+4. **Configuration** (optional): Publish the configuration file to customize the package settings.
+
+    ```bash
+    php artisan vendor:publish --tag=request-logger-config
+    ```
+
 ## Usage
 
 ### Logging Requests

--- a/src/app/Commands/SaveRequestsCommand.php
+++ b/src/app/Commands/SaveRequestsCommand.php
@@ -14,10 +14,11 @@ class SaveRequestsCommand extends Command
 
     public function handle(): void
     {
-        $requests = Cache::get('requests', []);
+        $cacheKey = config('request-logger.cache_key');
+        $requests = Cache::get($cacheKey, []);
         if (!empty($requests)) {
             $this->info('Saving ' . count($requests) . ' requests');
-            Cache::forget('requests');
+            Cache::forget($cacheKey);
             SaveRequestsJob::dispatch($requests);
         }
     }

--- a/src/app/Models/IpAddress.php
+++ b/src/app/Models/IpAddress.php
@@ -38,7 +38,7 @@ class IpAddress extends Model
     public static function getIdFromCacheOrCreate(string $ip): int
     {
         $ipHash = md5($ip);
-        $cacheKey = "ip_address_id_{$ipHash}";
+        $cacheKey = config('request-logger.models_cache_keys.ip_address') . $ipHash;
         $ipAddressId = Cache::has($cacheKey) ? Cache::get($cacheKey) : null;
 
         if ($ipAddressId === null) {

--- a/src/app/Models/MimeType.php
+++ b/src/app/Models/MimeType.php
@@ -19,7 +19,7 @@ class MimeType extends Model
     public static function getIdFromCacheOrCreate(string $mimeType): int
     {
         $mimeTypeHash = md5($mimeType);
-        $cacheKey = "mime_type_id_{$mimeTypeHash}";
+        $cacheKey = config('request-logger.models_cache_keys.mime_type') . $mimeTypeHash;
         $mimeTypeId = Cache::has($cacheKey) ? Cache::get($cacheKey) : null;
 
         if ($mimeTypeId === null) {

--- a/src/app/Models/Url.php
+++ b/src/app/Models/Url.php
@@ -19,7 +19,7 @@ class Url extends Model
     public static function getIdFromCacheOrCreate(string $url): int
     {
         $urlHash = md5($url);
-        $cacheKey = "url_id_{$urlHash}";
+        $cacheKey = config('request-logger.models_cache_keys.url') . $urlHash;
         $urlId = Cache::has($cacheKey) ? Cache::get($cacheKey) : null;
 
         if ($urlId === null) {

--- a/src/app/Models/UserAgent.php
+++ b/src/app/Models/UserAgent.php
@@ -21,7 +21,7 @@ class UserAgent extends Model
     {
         $userAgent = Str::before($userAgent, ';');
         $userAgentHash = md5($userAgent);
-        $cacheKey = "user_agent_id_{$userAgentHash}";
+        $cacheKey = config('request-logger.models_cache_keys.user_agent') . $userAgentHash;
         $userAgentId = Cache::has($cacheKey) ? Cache::get($cacheKey) : null;
 
         if ($userAgentId === null) {

--- a/src/app/Providers/LaravelRequestLogger.php
+++ b/src/app/Providers/LaravelRequestLogger.php
@@ -11,6 +11,9 @@ class LaravelRequestLogger extends ServiceProvider
     public function boot(): void
     {
         $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
+        $this->publishes([
+            __DIR__ . '/../../config/request-logger.php' => config_path('request-logger.php'),
+        ], 'request-logger-config');
 
         if ($this->app->runningInConsole()) {
             $this->commands([
@@ -22,5 +25,6 @@ class LaravelRequestLogger extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(SaveRequestMiddleware::class);
+        $this->mergeConfigFrom(__DIR__ . '/../../config/request-logger.php', 'request-logger');
     }
 }

--- a/src/config/request-logger.php
+++ b/src/config/request-logger.php
@@ -1,0 +1,11 @@
+<?php
+return [
+    'cache_key' => 'requests',
+    'cache_ttl' => 3600,
+    'models_cache_keys' => [
+        'ip_address' => 'ip_address_id_',
+        'mime_type' => 'mime_type_id_',
+        'url' => 'url_id_',
+        'user_agent' => 'user_agent_id_'
+    ]
+];


### PR DESCRIPTION
This pull request introduces several changes to the `LaravelRequestLogger` package, focusing on adding configuration options and improving cache key handling. The most important changes include adding a configuration file, updating cache key usage in various classes, and handling cache locks more robustly.

### Configuration Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R72-R77): Added instructions for publishing the configuration file to customize package settings.
* [`src/app/Providers/LaravelRequestLogger.php`](diffhunk://#diff-c0837ec0bfed1829e0f95ddda3179fab0cba60d3ebcef2ee0872e36891fed026R14-R16): Added code to publish and merge the configuration file during the package boot process. [[1]](diffhunk://#diff-c0837ec0bfed1829e0f95ddda3179fab0cba60d3ebcef2ee0872e36891fed026R14-R16) [[2]](diffhunk://#diff-c0837ec0bfed1829e0f95ddda3179fab0cba60d3ebcef2ee0872e36891fed026R28)
* [`src/config/request-logger.php`](diffhunk://#diff-da0145652a2d360c705427acd37e02743788cfc31560ff1b89a7d438188d851eR1-R11): Added a new configuration file with settings for cache keys and TTL values.

### Cache Key Updates:
* [`src/app/Commands/SaveRequestsCommand.php`](diffhunk://#diff-5216c6d19631364067fb6bbaa78c0c987f9f7902da5eabf13ce9c6d761e62909L17-R21): Updated to use the cache key from the configuration file.
* [`src/app/Http/Middleware/SaveRequestMiddleware.php`](diffhunk://#diff-6513ab38203fd2c9b40a7ee4efca4d056b79287795b6f1b755f17658cd4ce55aL19-R21): Updated to use the cache key and TTL from the configuration file and added error handling for cache lock timeouts. [[1]](diffhunk://#diff-6513ab38203fd2c9b40a7ee4efca4d056b79287795b6f1b755f17658cd4ce55aL19-R21) [[2]](diffhunk://#diff-6513ab38203fd2c9b40a7ee4efca4d056b79287795b6f1b755f17658cd4ce55aL36-R46)
* `src/app/Models/IpAddress.php`, `src/app/Models/MimeType.php`, `src/app/Models/Url.php`, `src/app/Models/UserAgent.php`: Updated to use model-specific cache keys from the configuration file. [[1]](diffhunk://#diff-e5dfaad8598f4948dfc87a06b44fafbec87c4cbe7fe334536ae1c3ddc85e133fL41-R41) [[2]](diffhunk://#diff-39378161f6e07f770cdab27e112462df9c46fe6ef4083ae6ef30fd2ae1e72ef7L22-R22) [[3]](diffhunk://#diff-ac3c0f6d43d7eb6ee4df866e33f9d6ed43afb8eb5db539a580ecf7de5189ef34L22-R22) [[4]](diffhunk://#diff-81d17b7d146122f10b7cf3a03ab8201ae7d3aea325a1d4077e0b6b776feb1261L24-R24)

These changes enhance the flexibility and robustness of the `LaravelRequestLogger` package by allowing customization of cache keys and improving error handling.